### PR TITLE
Failed to load error component

### DIFF
--- a/components/network-error/NetworkError.js
+++ b/components/network-error/NetworkError.js
@@ -1,0 +1,30 @@
+//HandleNetworkError accepts two props: children (which represents the content you want to render, such as description, instructions, or tags) and errorType, which specifies the type of error (description, instructions, or tags).
+const HandleNetworkError = ({ children, errorType }) => {
+  const errorMessage = getErrorMessage(errorType);
+
+  if (errorMessage) {
+    return (
+      <div>
+        <p>{errorMessage}</p>
+      </div>
+    );
+  }
+
+  return children;
+};
+
+//The getErrorMessage function maps the errorType to the appropriate error message.
+function getErrorMessage(errorType) {
+  switch (errorType) {
+    case "description":
+      return "Failed to load description";
+    case "instructions":
+      return "Failed to load instructions";
+    case "tags":
+      return "Failed to load tags";
+    default:
+      return null;
+  }
+}
+
+export default HandleNetworkError;


### PR DESCRIPTION
You can use the "HandleNetworkError" component for different parts of the recipe page (description, instructions, and tags). Depending on the specific error scenario you're given, you can pass the relevant errorType prop, and the "HandleNetworkError" component will handle displaying the appropriate error message or the content.